### PR TITLE
Get aggregate rating in php if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add the stars where you'd like in `resources/views/vendor/rapidez/product/overvi
 
 The review list can be added with:
 ```
-@include('rapidez-reviews::reviews', ['sku' => $product->sku])
+@include('rapidez-reviews::reviews', ['sku' => $product->sku, 'reviews_count' => $product->reviews_count, 'reviews_score' => $product->reviews_score])
 ```
 
 #### Review form

--- a/resources/views/reviews.blade.php
+++ b/resources/views/reviews.blade.php
@@ -1,14 +1,9 @@
-@php
-$reviews_count ??= 'data.products.items[0].reviews.items.length';
-$reviews_score ??= 'data.products.items[0].rating_summary';
-@endphp
-
 <graphql v-cloak query='@include('rapidez-reviews::queries.reviews', ['sku' => $sku])'>
     <div slot-scope="{ data }" v-if="data?.products.items[0].reviews">
         <strong class="block text-2xl mt-5">@lang('Customer Reviews')</strong>
         <div itemprop="aggregateRating" itemtype="https://schema.org/AggregateRating" itemscope>
-            <meta itemprop="reviewCount" {{ !is_numeric($reviews_count) ? 'v-bind:' : '' }}content="{{ $reviews_count }}" />
-            <meta itemprop="ratingValue" {{ !is_numeric($reviews_score) ? 'v-bind:' : '' }}content="{{ $reviews_score }}" />
+            <meta itemprop="reviewCount" content="{{ $reviews_count }}" />
+            <meta itemprop="ratingValue" content="{{ $reviews_score }}" />
             <meta itemprop="bestRating" content="100" />
         </div>
         <div v-for="review in data.products.items[0].reviews.items" class="w-full bg-gray-200 rounded p-3 mt-3" itemprop="review" itemtype="https://schema.org/Review" itemscope>

--- a/resources/views/reviews.blade.php
+++ b/resources/views/reviews.blade.php
@@ -1,9 +1,14 @@
-<graphql v-cloak query='@include('rapidez-reviews::queries.reviews', ['sku' => $product->sku])'>
+@php
+$reviews_count ??= 'data.products.items[0].reviews.items.length';
+$reviews_score ??= 'data.products.items[0].rating_summary';
+@endphp
+
+<graphql v-cloak query='@include('rapidez-reviews::queries.reviews', ['sku' => $sku])'>
     <div slot-scope="{ data }" v-if="data?.products.items[0].reviews">
         <strong class="block text-2xl mt-5">@lang('Customer Reviews')</strong>
         <div itemprop="aggregateRating" itemtype="https://schema.org/AggregateRating" itemscope>
-            <meta itemprop="reviewCount" :content="data.products.items[0].reviews.items.length" />
-            <meta itemprop="ratingValue" :content="data.products.items[0].rating_summary" />
+            <meta itemprop="reviewCount" {{ !is_numeric($reviews_count) ? 'v-bind:' : '' }}content="{{ $reviews_count }}" />
+            <meta itemprop="ratingValue" {{ !is_numeric($reviews_score) ? 'v-bind:' : '' }}content="{{ $reviews_score }}" />
             <meta itemprop="bestRating" content="100" />
         </div>
         <div v-for="review in data.products.items[0].reviews.items" class="w-full bg-gray-200 rounded p-3 mt-3" itemprop="review" itemtype="https://schema.org/Review" itemscope>
@@ -12,9 +17,9 @@
                 <span class="ml-2 text-xs">@{{ new Date(review.created_at).toLocaleDateString() }}</span>
             </p>
             <div itemprop="reviewRating" itemtype="https://schema.org/Rating" itemscope>
-                <meta itemprop="ratingValue" :content="review.average_rating" />
+                <meta itemprop="ratingValue" v-bind:content="review.average_rating" />
                 <meta itemprop="bestRating" content="100" />
-                <stars class="mt-1" :score="review.average_rating"></stars>
+                <stars class="mt-1" v-bind:score="review.average_rating"></stars>
             </div>
             <strong class="block mt-3" itemprop="name">@{{ review.summary }}</strong>
             <p class="mt-1 text-sm" itemprop="reviewBody">@{{ review.text }}</p>

--- a/resources/views/reviews.blade.php
+++ b/resources/views/reviews.blade.php
@@ -1,4 +1,4 @@
-<graphql v-cloak query='@include('rapidez-reviews::queries.reviews', ['sku' => $sku])'>
+<graphql v-cloak query='@include('rapidez-reviews::queries.reviews', @compact('sku'))'>
     <div slot-scope="{ data }" v-if="data?.products.items[0].reviews">
         <strong class="block text-2xl mt-5">@lang('Customer Reviews')</strong>
         <div itemprop="aggregateRating" itemtype="https://schema.org/AggregateRating" itemscope>


### PR DESCRIPTION
Because the aggregate rating is not available before js is executed Google Search Console gives errors.
Reviews count and reviews score is already available on the product so we can use that for the initial value