### PR TITLE
Removed incorrect join

### DIFF
--- a/src/Models/Scopes/WithReviewsScope.php
+++ b/src/Models/Scopes/WithReviewsScope.php
@@ -17,10 +17,6 @@ class WithReviewsScope implements Scope
                 $join->on($model->getTable().'.entity_id', '=', 'review_entity_summary.entity_pk_value')
                     ->where('review_entity_summary.entity_type', 1)
                     ->where('review_entity_summary.store_id', config('rapidez.store'));
-            })
-            ->leftJoin('review', function ($join) {
-                $join->on('review_entity_summary.primary_id', '=', 'review.review_id')
-                    ->where('review.status_id', '1');
             });
     }
 }


### PR DESCRIPTION
Not sure where this is used but it's incorrect and doesn't do anything here. Maybe reviews are needed somewhere else but not sure how that would work because `review_entity_summary.primary_id` is just the primary key, it's not linked to `review.review_id`. It's a summary, so it's not linked to an individual review.

This was added with: https://github.com/rapidez/reviews/pull/13